### PR TITLE
ci: Add GitLab CI template.

### DIFF
--- a/ci.template.yml
+++ b/ci.template.yml
@@ -1,0 +1,74 @@
+---
+
+# Issues to watch for future improvement:
+#   https://gitlab.com/gitlab-org/gitlab-ce/issues/28314
+
+image:
+  name: centos:7
+
+stages:
+  - build
+  - test
+  - deploy
+
+variables:
+  PROJECT_NAME: echo $$CI_PROJECT_NAME | cut -c 10-
+  # just pick the first one by default
+  PRIMARY_RPM: find RPMS/ -name '*.rpm' -print -quit
+
+before_script:
+  - |
+    set -euxo pipefail
+    eval export PROJECT_NAME="$(eval $PROJECT_NAME)"
+    yum -y -q install git
+
+build:
+  stage: build
+  artifacts:
+    name: RPMS
+    expire_in: 30 days
+    paths:
+      - RPMS/
+  script: |
+    git clone --depth 1 https://github.com/riboseinc/rpm-specs /usr/local/rpm-specs
+    ln -s "$CI_PROJECT_DIR" "/usr/local/rpm-specs/$PROJECT_NAME"
+    cd "/usr/local/rpm-specs/$PROJECT_NAME"
+    ./prepare.sh
+    # just for informational purposes
+    for file in ~/rpmbuild/RPMS/**/*.rpm; do echo "$file"; rpm -qlpv "$file"; echo; done
+    # make sure our artifacts are uploaded
+    mv ~/rpmbuild/RPMS "$CI_PROJECT_DIR"
+
+test:
+  stage: test
+  script: |
+    echo No tests for this package.
+
+.deploy:
+  only:
+    - master
+
+github-release:
+  extends: .deploy
+  stage: deploy
+  script: |
+    pkgver=$(rpm -qp --queryformat '%{VERSION}-%{RELEASE}' $(eval $PRIMARY_RPM))
+    # we need a newish ruby for create-github-release.rb
+    yum -y -q install centos-release-scl
+    yum -y -q install rh-ruby25
+    # workaround for scl_source bug/limitation
+    set +eu
+    source scl_source enable rh-ruby25
+    set -eu
+    # release it
+    git clone --depth 1 https://github.com/riboseinc/create-github-release
+    cd create-github-release
+    gem install bundler -v 1.16.4
+    bundle install
+    bundle exec ./create-github-release.rb \
+      "riboseinc/rpm-spec-$PROJECT_NAME" \
+      "$pkgver" \
+      --name "$PROJECT_NAME $pkgver" \
+      --release-notes "Automatically built in commit $(echo $CI_COMMIT_SHA | cut -c 1-8)." \
+      "$CI_PROJECT_DIR"/RPMS/**/*.rpm
+


### PR DESCRIPTION
This is not used in this repo, but is intended to be used by other rpm-spec-* repos.